### PR TITLE
Fix URL parameter 'proxyip' not overriding environment variable

### DIFF
--- a/src/handlers/main.js
+++ b/src/handlers/main.js
@@ -118,7 +118,10 @@ export async function handleRequest(request, env, ctx, connect) {
 			if (matchingUserID) {
 				if (url.pathname === `/${matchingUserID}` || url.pathname === `/sub/${matchingUserID}`) {
 					const isSubscription = url.pathname.startsWith('/sub/');
-					const proxyAddresses = PROXYIP ? PROXYIP.split(',').map(addr => addr.trim()) : proxyIPs;
+					// Priority: URL parameter > environment variable > default
+					const proxyAddresses = urlPROXYIP
+						? urlPROXYIP.split(',').map(addr => addr.trim())
+						: (PROXYIP ? PROXYIP.split(',').map(addr => addr.trim()) : proxyIPs);
 					const content = isSubscription ?
 						genSub(matchingUserID, host, proxyAddresses) :
 						getConfig(matchingUserID, host, proxyAddresses);


### PR DESCRIPTION
## Summary
- Fix bug where URL parameter `proxyip` was ignored when generating config page or subscription
- Now the priority is: URL parameter > environment variable > default
- Users can override proxyip via `?proxyip=1.1.1.1:443` in URLs like `/{userID}` or `/sub/{userID}`

## Test plan
- [ ] Access `/{userID}?proxyip=custom.proxy.com:443` and verify the generated config uses the custom proxy
- [ ] Access `/sub/{userID}?proxyip=custom.proxy.com:443` and verify the subscription uses the custom proxy
- [ ] Verify that without URL parameter, environment variable `PROXYIP` is still used
- [ ] Verify that without both, default `proxyIPs` is used

Fixes #265