### PR TITLE
Fix CF Worker CI failure by upgrading Node.js and wrangler-action

### DIFF
--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -86,13 +86,17 @@ jobs:
           WENV: 'prod'
           COMMIT_SHA: ${{ github.sha }}
 
-        # npm (and node16) are installed by wrangler-action in a pre-job setup
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "22"
+
       - name: 🏗 Get dependencies
         run: npm i
 
       - name: 📚 Wrangler publish
         # github.com/cloudflare/wrangler-action
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           # input overrides env-defaults, regardless


### PR DESCRIPTION
## Summary
- Add Node.js 22 setup step using `actions/setup-node@v3`
- Upgrade `cloudflare/wrangler-action` from `@2.0.0` to `@v3`

## Problem
The CF Worker workflow was failing because:
- `wrangler-action@2.0.0` uses Node.js v16.20.2 internally
- Latest Wrangler requires Node.js v20.0.0 or higher

Error message:
```
Wrangler requires at least Node.js v20.0.0. You are using v16.20.2.
```

## Test plan
- [ ] Verify CF Worker workflow passes after merge