### PR TITLE
Add Trojan protocol and HTTP proxy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ Thumbs.db
 .env
 node_modules/
 package-lock.json
-/socks5.js
+ref_code.js

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -21,3 +21,10 @@ export const byteToHex = Array.from({ length: 256 }, (_, i) => (i + 0x100).toStr
 export const at = 'QA==';
 export const pt = 'dmxlc3M=';
 export const ed = 'RUR0dW5uZWw=';
+
+/**
+ * Trojan protocol constants
+ */
+export const trojanPt = 'dHJvamFu'; // 'trojan' in base64
+export const TROJAN_CMD_TCP = 0x01;
+export const TROJAN_CMD_UDP = 0x03;

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -9,6 +9,12 @@
 export const defaultUserID = 'd342d11e-d424-4583-b36e-524ab1f0afa4';
 
 /**
+ * Default Trojan password
+ * If empty, uses the UUID as password
+ */
+export const defaultTrojanPassword = '';
+
+/**
  * Array of proxy server addresses with ports
  * Format: ['hostname:port', 'hostname:port']
  */
@@ -33,17 +39,21 @@ export const defaultSocks5Relay = false;
  * @param {string} env.UUID - User ID for authentication
  * @param {string} env.SOCKS5 - SOCKS5 proxy configuration
  * @param {string} env.SOCKS5_RELAY - SOCKS5 relay mode flag
+ * @param {string} env.TROJAN_PASSWORD - Trojan password (optional, uses UUID if not set)
  * @returns {Object} Request configuration
  */
 export function createRequestConfig(env = {}) {
-	const { UUID, SOCKS5, SOCKS5_RELAY } = env;
+	const { UUID, SOCKS5, SOCKS5_RELAY, TROJAN_PASSWORD } = env;
+	const userID = UUID || defaultUserID;
 	return {
-		userID: UUID || defaultUserID,
+		userID: userID,
+		trojanPassword: TROJAN_PASSWORD || defaultTrojanPassword || userID,
 		socks5Address: SOCKS5 || defaultSocks5Address,
 		socks5Relay: SOCKS5_RELAY === 'true' || defaultSocks5Relay,
 		proxyIP: null,
 		proxyPort: null,
-		enableSocks: false,
-		parsedSocks5Address: {}
+		// Proxy type: 'socks5' | 'http' | null
+		proxyType: null,
+		parsedProxyAddress: null
 	};
 }

--- a/src/protocol/trojan.js
+++ b/src/protocol/trojan.js
@@ -1,0 +1,150 @@
+/**
+ * Trojan protocol implementation
+ *
+ * Header format:
+ * [Password SHA224 (56 bytes hex)] [CRLF (2 bytes)] [Cmd (1 byte)] [AddrType (1 byte)] [Addr] [Port (2 bytes)] [CRLF (2 bytes)] [Payload]
+ */
+
+import { sha224 } from '../utils/crypto.js';
+import { TROJAN_CMD_TCP, TROJAN_CMD_UDP } from '../config/constants.js';
+
+/**
+ * Detects if buffer contains Trojan protocol header by checking password hash
+ * @param {ArrayBuffer} buffer - Buffer to check
+ * @param {string} password - Expected password (plain text)
+ * @returns {boolean} True if buffer is valid Trojan protocol
+ */
+export function isTrojanProtocol(buffer, password) {
+	if (buffer.byteLength < 58) {
+		return false;
+	}
+	const bytes = new Uint8Array(buffer);
+
+	// Check for CRLF at position 56-57
+	if (bytes[56] !== 0x0d || bytes[57] !== 0x0a) {
+		return false;
+	}
+
+	// Verify password hash matches
+	try {
+		const receivedPasswordHash = new TextDecoder().decode(bytes.slice(0, 56));
+		const expectedPasswordHash = sha224(password);
+		return receivedPasswordHash === expectedPasswordHash;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Processes Trojan protocol header
+ * @param {ArrayBuffer} buffer - Buffer containing Trojan header
+ * @param {string} password - Expected password (plain text)
+ * @returns {{
+ *   hasError: boolean,
+ *   message?: string,
+ *   addressRemote?: string,
+ *   addressType?: number,
+ *   portRemote?: number,
+ *   rawDataIndex?: number,
+ *   isUDP?: boolean
+ * }} Processed header information
+ */
+export function processTrojanHeader(buffer, password) {
+	if (buffer.byteLength < 58) {
+		return { hasError: true, message: 'Invalid Trojan data: too short' };
+	}
+
+	const bytes = new Uint8Array(buffer);
+	const dataView = new DataView(buffer);
+
+	// Extract password hash from header (first 56 bytes as hex string)
+	const receivedPasswordHash = new TextDecoder().decode(bytes.slice(0, 56));
+
+	// Compute expected password hash
+	const expectedPasswordHash = sha224(password);
+
+	// Verify password
+	if (receivedPasswordHash !== expectedPasswordHash) {
+		return { hasError: true, message: 'Invalid Trojan password' };
+	}
+
+	// Verify CRLF at bytes 56-57
+	if (bytes[56] !== 0x0d || bytes[57] !== 0x0a) {
+		return { hasError: true, message: 'Invalid Trojan header: missing CRLF' };
+	}
+
+	// Parse command at byte 58
+	const command = bytes[58];
+	if (command !== TROJAN_CMD_TCP && command !== TROJAN_CMD_UDP) {
+		return { hasError: true, message: `Unsupported Trojan command: ${command}` };
+	}
+
+	// Parse address type at byte 59
+	const addressType = bytes[59];
+	let addressValue, addressLength, addressValueIndex;
+
+	switch (addressType) {
+		case 1: // IPv4
+			addressLength = 4;
+			addressValueIndex = 60;
+			if (buffer.byteLength < addressValueIndex + addressLength + 2) {
+				return { hasError: true, message: 'Invalid Trojan header: IPv4 address truncated' };
+			}
+			addressValue = Array.from(bytes.slice(addressValueIndex, addressValueIndex + addressLength)).join('.');
+			break;
+		case 3: // Domain name
+			addressLength = bytes[60];
+			addressValueIndex = 61;
+			if (buffer.byteLength < addressValueIndex + addressLength + 2) {
+				return { hasError: true, message: 'Invalid Trojan header: domain name truncated' };
+			}
+			addressValue = new TextDecoder().decode(bytes.slice(addressValueIndex, addressValueIndex + addressLength));
+			break;
+		case 4: // IPv6
+			addressLength = 16;
+			addressValueIndex = 60;
+			if (buffer.byteLength < addressValueIndex + addressLength + 2) {
+				return { hasError: true, message: 'Invalid Trojan header: IPv6 address truncated' };
+			}
+			addressValue = Array.from({ length: 8 }, (_, i) =>
+				dataView.getUint16(addressValueIndex + i * 2).toString(16)
+			).join(':');
+			break;
+		default:
+			return { hasError: true, message: `Invalid Trojan address type: ${addressType}` };
+	}
+
+	// Parse port (2 bytes, big-endian, after address)
+	const portIndex = addressValueIndex + addressLength;
+	if (buffer.byteLength < portIndex + 2) {
+		return { hasError: true, message: 'Invalid Trojan header: port truncated' };
+	}
+	const portRemote = dataView.getUint16(portIndex);
+
+	// Verify second CRLF after port
+	const crlfIndex = portIndex + 2;
+	if (buffer.byteLength < crlfIndex + 2) {
+		return { hasError: true, message: 'Invalid Trojan header: missing final CRLF' };
+	}
+	if (bytes[crlfIndex] !== 0x0d || bytes[crlfIndex + 1] !== 0x0a) {
+		return { hasError: true, message: 'Invalid Trojan header: invalid final CRLF' };
+	}
+
+	// Raw data starts after final CRLF
+	const rawDataIndex = crlfIndex + 2;
+
+	if (!addressValue) {
+		return { hasError: true, message: `Address value is empty, address type is ${addressType}` };
+	}
+
+	console.log(`Trojan: target ${addressValue}:${portRemote}, UDP: ${command === TROJAN_CMD_UDP}`);
+
+	return {
+		hasError: false,
+		addressRemote: addressValue,
+		addressType: addressType === 3 ? 2 : addressType, // Map Trojan type 3 (domain) to VLESS type 2
+		portRemote,
+		rawDataIndex,
+		isUDP: command === TROJAN_CMD_UDP
+	};
+}

--- a/src/proxy/http.js
+++ b/src/proxy/http.js
@@ -1,0 +1,93 @@
+/**
+ * HTTP CONNECT proxy implementation
+ */
+
+/**
+ * Establishes HTTP CONNECT tunnel proxy connection.
+ * @param {number} addressType - Type of address (1=IPv4, 2=Domain, 3=IPv6)
+ * @param {string} addressRemote - Remote address to connect to
+ * @param {number} portRemote - Remote port to connect to
+ * @param {Function} log - Logging function
+ * @param {{username?: string, password?: string, hostname: string, port: number}} parsedHttpAddr - Parsed HTTP proxy address
+ * @param {Function} connect - Cloudflare socket connect function
+ * @param {Uint8Array} [initialData] - Initial data to send after connection established
+ * @returns {Promise<import("@cloudflare/workers-types").Socket|undefined>} Connected socket or undefined on failure
+ */
+export async function httpConnect(addressType, addressRemote, portRemote, log, parsedHttpAddr, connect, initialData = new Uint8Array(0)) {
+	const { username, password, hostname, port } = parsedHttpAddr;
+
+	// Connect to HTTP proxy server
+	const socket = connect({ hostname, port });
+	const writer = socket.writable.getWriter();
+	const reader = socket.readable.getReader();
+
+	try {
+		// Build CONNECT request
+		const auth = username && password ? `Proxy-Authorization: Basic ${btoa(`${username}:${password}`)}\r\n` : '';
+		const request = `CONNECT ${addressRemote}:${portRemote} HTTP/1.1\r\nHost: ${addressRemote}:${portRemote}\r\n${auth}User-Agent: Mozilla/5.0\r\nConnection: keep-alive\r\n\r\n`;
+
+		await writer.write(new TextEncoder().encode(request));
+		log('sent HTTP CONNECT request');
+
+		// Read HTTP response header (until \r\n\r\n)
+		let responseBuffer = new Uint8Array(0);
+		let headerEndIndex = -1;
+		let bytesRead = 0;
+
+		while (headerEndIndex === -1 && bytesRead < 8192) {
+			const { done, value } = await reader.read();
+			if (done) {
+				throw new Error('Connection closed before receiving HTTP response');
+			}
+			responseBuffer = new Uint8Array([...responseBuffer, ...value]);
+			bytesRead = responseBuffer.length;
+
+			// Find \r\n\r\n (0x0d 0x0a 0x0d 0x0a)
+			const crlfcrlf = responseBuffer.findIndex((_, i) =>
+				i < responseBuffer.length - 3 &&
+				responseBuffer[i] === 0x0d &&
+				responseBuffer[i + 1] === 0x0a &&
+				responseBuffer[i + 2] === 0x0d &&
+				responseBuffer[i + 3] === 0x0a
+			);
+			if (crlfcrlf !== -1) {
+				headerEndIndex = crlfcrlf + 4;
+			}
+		}
+
+		if (headerEndIndex === -1) {
+			throw new Error('Invalid HTTP response: header too large or malformed');
+		}
+
+		// Parse status code from response
+		const headerText = new TextDecoder().decode(responseBuffer.slice(0, headerEndIndex));
+		const statusMatch = headerText.split('\r\n')[0].match(/HTTP\/\d\.\d\s+(\d+)/);
+		if (!statusMatch) {
+			throw new Error('Invalid HTTP response format');
+		}
+
+		const statusCode = parseInt(statusMatch[1]);
+		log(`HTTP proxy response: ${headerText.split('\r\n')[0]}`);
+
+		if (statusCode < 200 || statusCode >= 300) {
+			throw new Error(`HTTP CONNECT failed: HTTP ${statusCode}`);
+		}
+
+		log('HTTP CONNECT tunnel established');
+
+		// Send initial data if provided
+		if (initialData.length > 0) {
+			await writer.write(initialData);
+		}
+
+		writer.releaseLock();
+		reader.releaseLock();
+		return socket;
+	} catch (error) {
+		log(`HTTP CONNECT error: ${error.message}`);
+		try { writer.releaseLock(); } catch (e) { }
+		try { reader.releaseLock(); } catch (e) { }
+		try { socket.close(); } catch (e) { }
+		return undefined;
+	}
+}

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -1,0 +1,118 @@
+/**
+ * Cryptographic utilities for Trojan protocol
+ * SHA224 implementation based on cmliu/edgetunnel
+ */
+
+/**
+ * Computes SHA224 hash of a string
+ * @param {string} str - String to hash
+ * @returns {string} Hex-encoded SHA224 hash (56 characters)
+ */
+export function sha224(str) {
+	function rightRotate(value, amount) {
+		return (value >>> amount) | (value << (32 - amount));
+	}
+
+	const mathPow = Math.pow;
+	const maxWord = mathPow(2, 32);
+	let result = '';
+
+	const words = [];
+	const asciiBitLength = str.length * 8;
+
+	// Initial hash values - SHA224 specific (first 32 bits of the fractional parts of square roots of 9th through 16th primes)
+	let hash = [
+		0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939,
+		0xffc00b31, 0x68581511, 0x64f98fa7, 0xbefa4fa4
+	];
+
+	// Round constants (first 32 bits of the fractional parts of cube roots of first 64 primes)
+	const k = [
+		0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+		0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+		0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+		0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+		0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+		0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+		0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+		0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+	];
+
+	// Pre-processing: add padding bits
+	let i, j;
+	str += '\x80'; // Append '1' bit (plus zero padding)
+	while (str.length % 64 - 56) str += '\x00'; // More zero padding
+
+	for (i = 0; i < str.length; i++) {
+		j = str.charCodeAt(i);
+		if (j >> 8) return; // ASCII check
+		words[i >> 2] |= j << ((3 - i) % 4) * 8;
+	}
+	words[words.length] = ((asciiBitLength / maxWord) | 0);
+	words[words.length] = (asciiBitLength);
+
+	// Process each chunk
+	for (j = 0; j < words.length;) {
+		const w = words.slice(j, j += 16);
+		const oldHash = hash.slice(0);
+
+		for (i = 0; i < 64; i++) {
+			// Expand the message schedule
+			if (i >= 16) {
+				const w15 = w[i - 15], w2 = w[i - 2];
+				w[i] = (
+					w[i - 16] +
+					(rightRotate(w15, 7) ^ rightRotate(w15, 18) ^ (w15 >>> 3)) +
+					w[i - 7] +
+					(rightRotate(w2, 17) ^ rightRotate(w2, 19) ^ (w2 >>> 10))
+				) | 0;
+			}
+
+			// Compression function main loop
+			const a = hash[0], e = hash[4];
+			const temp1 = (
+				hash[7] +
+				(rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25)) +
+				((e & hash[5]) ^ (~e & hash[6])) +
+				k[i] +
+				w[i]
+			);
+			const temp2 = (
+				(rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22)) +
+				((a & hash[1]) ^ (a & hash[2]) ^ (hash[1] & hash[2]))
+			);
+
+			hash = [(temp1 + temp2) | 0].concat(hash);
+			hash[4] = (hash[4] + temp1) | 0;
+			hash.pop();
+		}
+
+		for (i = 0; i < 8; i++) {
+			hash[i] = (hash[i] + oldHash[i]) | 0;
+		}
+	}
+
+	// Produce the final hash value (SHA224 uses only first 7 words = 224 bits)
+	for (i = 0; i < 7; i++) {
+		const hex = hash[i];
+		result += ((hex >> 28) & 0xf).toString(16) +
+			((hex >> 24) & 0xf).toString(16) +
+			((hex >> 20) & 0xf).toString(16) +
+			((hex >> 16) & 0xf).toString(16) +
+			((hex >> 12) & 0xf).toString(16) +
+			((hex >> 8) & 0xf).toString(16) +
+			((hex >> 4) & 0xf).toString(16) +
+			(hex & 0xf).toString(16);
+	}
+
+	return result;
+}
+
+/**
+ * Computes SHA224 hash of password for Trojan protocol
+ * @param {string} password - Password to hash
+ * @returns {string} 56-character hex string
+ */
+export function hashTrojanPassword(password) {
+	return sha224(password);
+}

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -92,3 +92,93 @@ export function parseEncodedQueryParams(pathname) {
 	}
 	return params;
 }
+
+/**
+ * Decodes proxy address with Base64 encoded username:password.
+ * @param {string} address - Address string (may contain Base64 encoded credentials)
+ * @returns {string} Decoded address string
+ */
+function decodeProxyAddress(address) {
+	if (!address.includes('@')) return address;
+
+	const atIndex = address.lastIndexOf('@');
+	let userPass = address.substring(0, atIndex).replace(/%3D/gi, '=');
+	const hostPort = address.substring(atIndex + 1);
+
+	// Try Base64 decode if it looks like Base64 and doesn't contain ':'
+	if (/^[A-Za-z0-9+/]+=*$/.test(userPass) && !userPass.includes(':')) {
+		try {
+			userPass = atob(userPass);
+		} catch (e) {
+			// Not valid Base64, keep original
+		}
+	}
+
+	return `${userPass}@${hostPort}`;
+}
+
+/**
+ * Parses path-based proxy parameters.
+ * Supports formats: /proxyip=, /proxyip., /socks5=, /socks://, /socks5://, /http=, /http://
+ * @param {string} pathname - URL pathname
+ * @returns {{proxyip: string|null, socks5: string|null, http: string|null, globalProxy: boolean}} Parsed parameters
+ */
+export function parsePathProxyParams(pathname) {
+	const result = {
+		proxyip: null,
+		socks5: null,
+		http: null,
+		globalProxy: false
+	};
+
+	// 1. Match /proxyip=host:port, /proxyip.domain.com, /pyip=, /ip=
+	const proxyipMatch = pathname.match(/^\/(proxyip[.=]|pyip=|ip=)([^/?#]+)/i);
+	if (proxyipMatch) {
+		const prefix = proxyipMatch[1].toLowerCase();
+		const value = proxyipMatch[2];
+		result.proxyip = prefix === 'proxyip.' ? `proxyip.${value}` : value;
+		return result;
+	}
+
+	// 2. Match /socks://base64@host:port or /socks5://user:pass@host:port
+	const socksUrlMatch = pathname.match(/^\/(socks5?):\/\/?([^/?#]+)/i);
+	if (socksUrlMatch) {
+		result.socks5 = decodeProxyAddress(socksUrlMatch[2]);
+		result.globalProxy = true;
+		return result;
+	}
+
+	// 3. Match /socks5=, /socks=, /s5=, /gs5=, /gsocks5=
+	const socksEqMatch = pathname.match(/^\/(g?s5|g?socks5?)=([^/?#]+)/i);
+	if (socksEqMatch) {
+		const type = socksEqMatch[1].toLowerCase();
+		result.socks5 = socksEqMatch[2];
+		// g prefix enables global proxy mode
+		if (type.startsWith('g')) {
+			result.globalProxy = true;
+		}
+		return result;
+	}
+
+	// 4. Match /http://user:pass@host:port
+	const httpUrlMatch = pathname.match(/^\/http:\/\/?([^/?#]+)/i);
+	if (httpUrlMatch) {
+		result.http = decodeProxyAddress(httpUrlMatch[1]);
+		result.globalProxy = true;
+		return result;
+	}
+
+	// 5. Match /http=user:pass@host:port or /ghttp= (global mode)
+	const httpEqMatch = pathname.match(/^\/(g?http)=([^/?#]+)/i);
+	if (httpEqMatch) {
+		const type = httpEqMatch[1].toLowerCase();
+		result.http = httpEqMatch[2];
+		// g prefix enables global proxy mode
+		if (type.startsWith('g')) {
+			result.globalProxy = true;
+		}
+		return result;
+	}
+
+	return result;
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,5 +7,6 @@ workers_dev = true
 [vars]
 # PROXYIP = "211.230.110.231:50008"
 UUID = "1b6c1745-992e-4aac-8685-266c090e50ea"
+# TROJAN_PASSWORD = "your-trojan-password"  # Optional: If not set, UUID will be used as password
 # SOCKS5 = "127.0.0.1:1080"
 # SOCKS5_RELAY = "true"


### PR DESCRIPTION
## Summary
- Add Trojan protocol support with automatic detection alongside existing VLESS protocol
- Implement HTTP CONNECT proxy as an alternative to SOCKS5 proxy
- Support flexible path-based proxy parameters (`/socks5://`, `/http://`, `/proxyip=`)
- Add global proxy mode for routing all traffic through configured proxy
- Generate Trojan-specific subscription URLs and update configuration pages
- Add `TROJAN_PASSWORD` environment variable (defaults to UUID if not set)

## Test plan
- [ ] Verify VLESS connections still work as expected
- [ ] Test Trojan protocol connections via WebSocket
- [ ] Test HTTP proxy connections with `/http://` path parameter
- [ ] Test SOCKS5 proxy connections with `/socks5://` path parameter
- [ ] Verify Trojan subscription generation at `/trojan/{uuid}` endpoint
- [ ] Test global proxy mode with `?globalproxy` query parameter
- [ ] Verify configuration page displays both VLESS and Trojan options