### PR TITLE
feat(proxy): add VLESS outbound proxy support with full UDP capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Thumbs.db
 node_modules/
 package-lock.json
 ref_code.js
+test/

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -28,3 +28,21 @@ export const ed = 'RUR0dW5uZWw=';
 export const trojanPt = 'dHJvamFu'; // 'trojan' in base64
 export const TROJAN_CMD_TCP = 0x01;
 export const TROJAN_CMD_UDP = 0x03;
+
+/**
+ * VLESS protocol command types
+ */
+export const VLESS_CMD_TCP = 0x01;
+export const VLESS_CMD_UDP = 0x02;
+
+/**
+ * VLESS protocol address types
+ */
+export const VLESS_ADDR_IPV4 = 1;
+export const VLESS_ADDR_DOMAIN = 2;
+export const VLESS_ADDR_IPV6 = 3;
+
+/**
+ * Default VLESS outbound connection timeout in milliseconds
+ */
+export const VLESS_OUTBOUND_TIMEOUT = 10000;

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -47,6 +47,12 @@ export const defaultProxyTimeout = 1500;
 export const defaultEnableProxyFallback = true;
 
 /**
+ * Default VLESS outbound configuration
+ * Format: 'vless://uuid@host:port?type=ws&security=tls&path=/path'
+ */
+export const defaultVlessOutbound = '';
+
+/**
  * Creates a request configuration object with default values
  * @param {Object} env - Environment variables
  * @param {string} env.UUID - User ID for authentication
@@ -55,10 +61,11 @@ export const defaultEnableProxyFallback = true;
  * @param {string} env.TROJAN_PASSWORD - Trojan password (optional, uses UUID if not set)
  * @param {string} env.PROXY_TIMEOUT - Proxy connection timeout in ms
  * @param {string} env.PROXY_FALLBACK - Enable fallback to direct connection
+ * @param {string} env.VLESS_OUTBOUND - VLESS outbound configuration URL
  * @returns {Object} Request configuration
  */
 export function createRequestConfig(env = {}) {
-	const { UUID, SOCKS5, SOCKS5_RELAY, TROJAN_PASSWORD, PROXY_TIMEOUT, PROXY_FALLBACK } = env;
+	const { UUID, SOCKS5, SOCKS5_RELAY, TROJAN_PASSWORD, PROXY_TIMEOUT, PROXY_FALLBACK, VLESS_OUTBOUND } = env;
 	const userID = UUID || defaultUserID;
 	return {
 		userID: userID,
@@ -67,11 +74,14 @@ export function createRequestConfig(env = {}) {
 		socks5Relay: SOCKS5_RELAY === 'true' || defaultSocks5Relay,
 		proxyIP: null,
 		proxyPort: null,
-		// Proxy type: 'socks5' | 'http' | null
+		// Proxy type: 'socks5' | 'http' | 'vless' | null
 		proxyType: null,
 		parsedProxyAddress: null,
 		// Multi-proxy rotation settings
 		proxyTimeout: PROXY_TIMEOUT ? parseInt(PROXY_TIMEOUT, 10) : defaultProxyTimeout,
-		enableProxyFallback: PROXY_FALLBACK !== 'false' && defaultEnableProxyFallback
+		enableProxyFallback: PROXY_FALLBACK !== 'false' && defaultEnableProxyFallback,
+		// VLESS outbound configuration
+		vlessOutbound: VLESS_OUTBOUND || defaultVlessOutbound,
+		parsedVlessOutbound: null
 	};
 }

--- a/src/proxy/udp-handler.js
+++ b/src/proxy/udp-handler.js
@@ -1,0 +1,97 @@
+/**
+ * UDP outbound connection handler
+ * Manages UDP traffic routing through VLESS outbound proxy
+ */
+
+import { WS_READY_STATE_OPEN } from '../config/constants.js';
+import { safeCloseWebSocket } from '../utils/websocket.js';
+import { vlessOutboundConnect, VLESS_CMD_UDP } from './vless.js';
+
+/**
+ * Checks if the current configuration can handle UDP traffic
+ * @param {Object} config - Request configuration
+ * @returns {boolean} True if UDP can be handled
+ */
+export function canHandleUDP(config) {
+	// VLESS outbound supports UDP natively
+	if (config.proxyType === 'vless' && config.parsedVlessOutbound) {
+		return true;
+	}
+	// Native UDP support could be added here in the future
+	// if (platformAPI.associate != null) return true;
+	return false;
+}
+
+/**
+ * Handles UDP outbound connections via VLESS proxy
+ * @param {WebSocket} webSocket - Client WebSocket connection
+ * @param {Uint8Array|null} protocolResponseHeader - VLESS response header
+ * @param {number} addressType - Destination address type
+ * @param {string} addressRemote - Destination address
+ * @param {number} portRemote - Destination port
+ * @param {Uint8Array} rawClientData - Raw client data after header
+ * @param {Function} log - Logging function
+ * @param {Object} config - Request configuration
+ * @returns {Promise<WritableStream|null>} Writable stream for subsequent data, or null on failure
+ */
+export async function handleUDPOutbound(webSocket, protocolResponseHeader, addressType, addressRemote, portRemote, rawClientData, log, config) {
+	// Only VLESS outbound supports UDP currently
+	if (config.proxyType !== 'vless' || !config.parsedVlessOutbound) {
+		log('[UDP] No UDP-capable outbound configured');
+		safeCloseWebSocket(webSocket);
+		return null;
+	}
+
+	log(`[UDP] Establishing VLESS outbound for UDP://${addressRemote}:${portRemote}`);
+
+	// Connect via VLESS outbound
+	const vlessResult = await vlessOutboundConnect(config.parsedVlessOutbound, VLESS_CMD_UDP, addressType, addressRemote, portRemote, rawClientData, log);
+
+	if (!vlessResult) {
+		log('[UDP] VLESS outbound connection failed');
+		safeCloseWebSocket(webSocket);
+		return null;
+	}
+
+	let headerSent = false;
+
+	// Pipe VLESS readable stream to client WebSocket
+	vlessResult.readable
+		.pipeTo(
+			new WritableStream({
+				write(data) {
+					if (webSocket.readyState !== WS_READY_STATE_OPEN) {
+						return;
+					}
+
+					// Add protocol response header to first response
+					if (!headerSent && protocolResponseHeader) {
+						const combined = new Uint8Array(protocolResponseHeader.length + data.length);
+						combined.set(protocolResponseHeader, 0);
+						combined.set(data, protocolResponseHeader.length);
+						webSocket.send(combined.buffer);
+						headerSent = true;
+					} else {
+						webSocket.send(data);
+					}
+				},
+				close() {
+					log('[UDP] VLESS readable stream closed');
+					safeCloseWebSocket(webSocket);
+				},
+				abort(reason) {
+					log(`[UDP] VLESS readable stream aborted: ${reason}`);
+					safeCloseWebSocket(webSocket);
+				},
+			})
+		)
+		.catch((err) => {
+			log(`[UDP] VLESS pipe error: ${err.message || err}`);
+			safeCloseWebSocket(webSocket);
+		});
+
+	log('[UDP] VLESS outbound established successfully');
+
+	// Return the writable stream for subsequent WebSocket messages
+	return vlessResult.writable;
+}

--- a/src/proxy/udp.js
+++ b/src/proxy/udp.js
@@ -1,0 +1,123 @@
+/**
+ * UDP stream processing utilities
+ * Handles UDP datagram framing for VLESS protocol
+ */
+
+/**
+ * Joins two Uint8Arrays into a single array
+ * @param {Uint8Array} arr1 - First array
+ * @param {Uint8Array} arr2 - Second array
+ * @returns {Uint8Array} Combined array
+ */
+export function joinUint8Array(arr1, arr2) {
+	const result = new Uint8Array(arr1.length + arr2.length);
+	result.set(arr1, 0);
+	result.set(arr2, arr1.length);
+	return result;
+}
+
+/**
+ * Creates a readable stream that wraps UDP datagrams with length prefix
+ * Each datagram is prepended with a 16-bit big-endian length field
+ * @param {Object} udpClient - UDP client with onmessage and onerror handlers
+ * @param {Function} log - Logging function
+ * @returns {ReadableStream}
+ */
+export function makeReadableUDPStream(udpClient, log) {
+	return new ReadableStream({
+		start(controller) {
+			udpClient.onmessage((message, info) => {
+				// Prepend 16-bit big-endian length header
+				const header = new Uint8Array([(info.size >> 8) & 0xff, info.size & 0xff]);
+				const encodedChunk = joinUint8Array(header, message);
+				controller.enqueue(encodedChunk);
+			});
+
+			udpClient.onerror((error) => {
+				log(`[UDP] Socket error: ${error.message || error}`);
+				controller.error(error);
+			});
+		},
+		cancel(reason) {
+			log(`[UDP] ReadableStream canceled: ${reason}`);
+			try {
+				udpClient.close();
+			} catch (e) {
+				// Ignore close errors
+			}
+		},
+	});
+}
+
+/**
+ * Creates a writable stream that unpacks length-prefixed UDP datagrams
+ * @param {Object} udpClient - UDP client with send method
+ * @param {string} addressRemote - Remote address
+ * @param {number} portRemote - Remote port
+ * @param {Function} log - Logging function
+ * @returns {WritableStream}
+ */
+export function makeWritableUDPStream(udpClient, addressRemote, portRemote, log) {
+	let leftoverData = new Uint8Array(0);
+
+	return new WritableStream({
+		write(chunk, controller) {
+			let byteArray = new Uint8Array(chunk);
+
+			// Merge with leftover data from previous chunk
+			if (leftoverData.length > 0) {
+				byteArray = joinUint8Array(leftoverData, byteArray);
+				leftoverData = new Uint8Array(0);
+			}
+
+			let offset = 0;
+			while (offset < byteArray.length) {
+				// Need at least 2 bytes for length field
+				if (offset + 1 >= byteArray.length) {
+					leftoverData = byteArray.slice(offset);
+					break;
+				}
+
+				// Read 16-bit big-endian length
+				const datagramLen = (byteArray[offset] << 8) | byteArray[offset + 1];
+
+				// Check if we have the complete datagram
+				if (offset + 2 + datagramLen > byteArray.length) {
+					leftoverData = byteArray.slice(offset);
+					break;
+				}
+
+				// Extract and send the datagram
+				const datagram = byteArray.slice(offset + 2, offset + 2 + datagramLen);
+				udpClient.send(datagram, 0, datagramLen, portRemote, addressRemote, (err) => {
+					if (err) {
+						log(`[UDP] Send error: ${err.message || err}`);
+						controller.error(err);
+					}
+				});
+
+				offset += 2 + datagramLen;
+			}
+		},
+		close() {
+			log('[UDP] WritableStream closed');
+		},
+		abort(reason) {
+			log(`[UDP] WritableStream aborted: ${reason}`);
+		},
+	});
+}
+
+/**
+ * Safely closes a UDP socket
+ * @param {Object} socket - UDP socket
+ */
+export function safeCloseUDP(socket) {
+	try {
+		if (socket && typeof socket.close === 'function') {
+			socket.close();
+		}
+	} catch (error) {
+		console.error('[UDP] Safe close error:', error);
+	}
+}

--- a/src/proxy/vless.js
+++ b/src/proxy/vless.js
@@ -1,0 +1,369 @@
+/**
+ * VLESS outbound proxy implementation
+ * Connects to a remote VLESS server via WebSocket
+ */
+
+import { WS_READY_STATE_OPEN } from '../config/constants.js';
+import { safeCloseWebSocket } from '../utils/websocket.js';
+
+/**
+ * VLESS command types
+ */
+export const VLESS_CMD_TCP = 0x01;
+export const VLESS_CMD_UDP = 0x02;
+
+/**
+ * VLESS address types
+ */
+export const VLESS_ADDR_IPV4 = 1;
+export const VLESS_ADDR_DOMAIN = 2;
+export const VLESS_ADDR_IPV6 = 3;
+
+/**
+ * Default VLESS outbound connection timeout in milliseconds
+ */
+export const VLESS_OUTBOUND_TIMEOUT = 10000;
+
+/**
+ * Generates a VLESS request header
+ * @param {number} command - Command type (1=TCP, 2=UDP)
+ * @param {number} addressType - Address type (1=IPv4, 2=Domain, 3=IPv6)
+ * @param {string} addressRemote - Remote address
+ * @param {number} portRemote - Remote port
+ * @param {string} uuid - UUID for authentication
+ * @returns {Uint8Array} VLESS request header
+ */
+export function makeVlessRequestHeader(command, addressType, addressRemote, portRemote, uuid) {
+	let addressFieldLength;
+	let addressEncoded;
+
+	switch (addressType) {
+		case VLESS_ADDR_IPV4:
+			addressFieldLength = 4;
+			break;
+		case VLESS_ADDR_DOMAIN:
+			addressEncoded = new TextEncoder().encode(addressRemote);
+			addressFieldLength = addressEncoded.length + 1;
+			break;
+		case VLESS_ADDR_IPV6:
+			addressFieldLength = 16;
+			break;
+		default:
+			throw new Error(`Unknown address type: ${addressType}`);
+	}
+
+	const uuidString = uuid.replace(/-/g, '');
+	const vlessHeader = new Uint8Array(22 + addressFieldLength);
+
+	// Protocol Version = 0
+	vlessHeader[0] = 0x00;
+
+	// UUID (16 bytes)
+	for (let i = 0; i < uuidString.length; i += 2) {
+		vlessHeader[1 + i / 2] = parseInt(uuidString.substr(i, 2), 16);
+	}
+
+	// Additional Information Length = 0
+	vlessHeader[17] = 0x00;
+
+	// Command
+	vlessHeader[18] = command;
+
+	// Port (2-byte big-endian)
+	vlessHeader[19] = portRemote >> 8;
+	vlessHeader[20] = portRemote & 0xff;
+
+	// Address Type
+	vlessHeader[21] = addressType;
+
+	// Address
+	switch (addressType) {
+		case VLESS_ADDR_IPV4:
+			const octets = addressRemote.split('.');
+			for (let i = 0; i < 4; i++) {
+				vlessHeader[22 + i] = parseInt(octets[i]);
+			}
+			break;
+		case VLESS_ADDR_DOMAIN:
+			vlessHeader[22] = addressEncoded.length;
+			vlessHeader.set(addressEncoded, 23);
+			break;
+		case VLESS_ADDR_IPV6:
+			// Handle both full and compressed IPv6 formats
+			const fullIPv6 = expandIPv6(addressRemote);
+			const groups = fullIPv6.split(':');
+			for (let i = 0; i < 8; i++) {
+				const hexGroup = parseInt(groups[i], 16);
+				vlessHeader[22 + i * 2] = hexGroup >> 8;
+				vlessHeader[23 + i * 2] = hexGroup & 0xff;
+			}
+			break;
+	}
+
+	return vlessHeader;
+}
+
+/**
+ * Expands a compressed IPv6 address to full format
+ * @param {string} ipv6 - IPv6 address (may be compressed)
+ * @returns {string} Full IPv6 address
+ */
+function expandIPv6(ipv6) {
+	// Remove brackets if present
+	ipv6 = ipv6.replace(/^\[|\]$/g, '');
+
+	// Handle :: compression
+	if (ipv6.includes('::')) {
+		const parts = ipv6.split('::');
+		const left = parts[0] ? parts[0].split(':') : [];
+		const right = parts[1] ? parts[1].split(':') : [];
+		const missing = 8 - left.length - right.length;
+		const middle = Array(missing).fill('0');
+		return [...left, ...middle, ...right].map((g) => g.padStart(4, '0')).join(':');
+	}
+
+	return ipv6
+		.split(':')
+		.map((g) => g.padStart(4, '0'))
+		.join(':');
+}
+
+/**
+ * Validates VLESS outbound configuration
+ * @param {string} address - Server address
+ * @param {Object} streamSettings - Stream settings
+ * @throws {Error} If configuration is invalid
+ */
+function validateVlessConfig(address, streamSettings) {
+	if (streamSettings.network !== 'ws') {
+		throw new Error(`Unsupported network type: ${streamSettings.network}, must be 'ws'`);
+	}
+	if (streamSettings.security !== 'tls' && streamSettings.security !== 'none' && streamSettings.security !== '') {
+		throw new Error(`Unsupported security: ${streamSettings.security}, must be 'tls' or 'none'`);
+	}
+}
+
+/**
+ * Establishes VLESS outbound connection via WebSocket
+ * @param {Object} config - VLESS outbound configuration
+ * @param {string} config.address - VLESS server address
+ * @param {number} config.port - VLESS server port
+ * @param {string} config.uuid - VLESS UUID for authentication
+ * @param {Object} config.streamSettings - Stream settings
+ * @param {number} command - Command type (TCP/UDP)
+ * @param {number} addressType - Destination address type
+ * @param {string} addressRemote - Destination address
+ * @param {number} portRemote - Destination port
+ * @param {Uint8Array} rawClientData - Initial client data
+ * @param {Function} log - Logging function
+ * @param {number} [timeout=10000] - Connection timeout in ms
+ * @returns {Promise<{readable: ReadableStream, writable: WritableStream, closed: Promise<void>}|null>}
+ */
+export async function vlessOutboundConnect(config, command, addressType, addressRemote, portRemote, rawClientData, log, timeout = VLESS_OUTBOUND_TIMEOUT) {
+	try {
+		validateVlessConfig(config.address, config.streamSettings);
+	} catch (err) {
+		log(`[VLESS] Config validation failed: ${err.message}`);
+		return null;
+	}
+
+	// Build WebSocket URL
+	const security = config.streamSettings.security || 'none';
+	let wsURL = security === 'tls' ? 'wss://' : 'ws://';
+	wsURL += `${config.address}:${config.port}`;
+	if (config.streamSettings.wsSettings?.path) {
+		wsURL += config.streamSettings.wsSettings.path;
+	}
+
+	const protocol = command === VLESS_CMD_UDP ? 'UDP' : 'TCP';
+	log(`[VLESS] Connecting to ${wsURL} for ${protocol}://${addressRemote}:${portRemote}`);
+
+	// Create WebSocket connection
+	log(`[VLESS] Creating WebSocket to ${wsURL}...`);
+	let ws;
+	try {
+		ws = new WebSocket(wsURL);
+		log(`[VLESS] WebSocket object created, readyState: ${ws.readyState}`);
+	} catch (err) {
+		log(`[VLESS] Failed to create WebSocket: ${err.message}`);
+		return null;
+	}
+
+	// Create a Promise that resolves when the WebSocket closes
+	let closedResolve;
+	const closedPromise = new Promise((resolve) => {
+		closedResolve = resolve;
+	});
+
+	// Wait for connection to open
+	log(`[VLESS] Waiting for WebSocket to open (timeout: ${timeout}ms)...`);
+	try {
+		await new Promise((resolve, reject) => {
+			const timeoutId = setTimeout(() => {
+				log(`[VLESS] Connection timeout after ${timeout}ms`);
+				reject(new Error('Connection timeout'));
+			}, timeout);
+
+			ws.addEventListener('open', () => {
+				log(`[VLESS] WebSocket open event received`);
+				clearTimeout(timeoutId);
+				resolve();
+			});
+
+			ws.addEventListener('close', (event) => {
+				log(`[VLESS] WebSocket close event during connect (code: ${event.code})`);
+				clearTimeout(timeoutId);
+				reject(new Error(`WebSocket closed with code ${event.code}`));
+			});
+
+			ws.addEventListener('error', (err) => {
+				log(`[VLESS] WebSocket error event during connect: ${err?.message || 'unknown'}`);
+				clearTimeout(timeoutId);
+				reject(new Error('WebSocket connection error'));
+			});
+		});
+	} catch (err) {
+		log(`[VLESS] Connection failed: ${err.message}`);
+		try {
+			ws.close();
+		} catch (e) {
+			// Ignore close errors
+		}
+		closedResolve();
+		return null;
+	}
+
+	log('[VLESS] Connection promise resolved, setting up handlers...');
+
+	try {
+		// Set up close handler to resolve the closed Promise
+		ws.addEventListener('close', (event) => {
+			log(`[VLESS] WebSocket connection closed (code: ${event.code}, reason: ${event.reason || 'none'})`);
+			closedResolve();
+		});
+
+		ws.addEventListener('error', () => {
+			log(`[VLESS] WebSocket error event`);
+		});
+
+		log('[VLESS] Creating writable stream...');
+		// Create writable stream for sending data to VLESS server
+		/** @type {WritableStream<Uint8Array>} */
+		const writableStream = new WritableStream({
+			write(chunk) {
+				if (ws.readyState === WS_READY_STATE_OPEN) {
+					ws.send(chunk);
+				}
+			},
+			close() {
+				log('[VLESS] Writable stream closed');
+				safeCloseWebSocket(ws);
+			},
+			abort(reason) {
+				log(`[VLESS] Writable stream aborted: ${reason}`);
+				safeCloseWebSocket(ws);
+			},
+		});
+
+		log('[VLESS] Writable stream created');
+
+		// Create readable stream with VLESS response header stripping
+		let headerStripped = false;
+		log('[VLESS] Creating readable stream with message handlers...');
+		const readableStream = new ReadableStream({
+			start(controller) {
+				log('[VLESS] ReadableStream start called, adding message listener');
+				ws.addEventListener('message', (event) => {
+					log(`[VLESS] Message received from VLESS server, size=${event.data?.byteLength || 'unknown'}`);
+					let data = new Uint8Array(event.data);
+
+					// Strip VLESS response header on first message
+					// Format: [version (1 byte)] [additional info length (1 byte)] [additional info (N bytes)]
+					if (!headerStripped) {
+						headerStripped = true;
+						log(`[VLESS] First message - stripping header. Raw length=${data.length}, first bytes: ${data.slice(0, Math.min(10, data.length)).join(',')}`);
+						if (data.length >= 2) {
+							const additionalBytes = data[1];
+							log(`[VLESS] Additional info bytes: ${additionalBytes}`);
+							if (data.length > 2 + additionalBytes) {
+								data = data.slice(2 + additionalBytes);
+								log(`[VLESS] After header strip, data length=${data.length}`);
+							} else {
+								// Response header only, no data
+								log('[VLESS] Response header only, no payload data');
+								return;
+							}
+						}
+					}
+
+					if (data.length > 0) {
+						log(`[VLESS] Enqueueing ${data.length} bytes to readable stream`);
+						controller.enqueue(data);
+					}
+				});
+
+				ws.addEventListener('close', () => {
+					log('[VLESS] ReadableStream: WebSocket close event');
+					try {
+						controller.close();
+					} catch (e) {
+						// Controller may already be closed
+					}
+				});
+
+				ws.addEventListener('error', (err) => {
+					log(`[VLESS] ReadableStream: WebSocket error event: ${err?.message || 'unknown'}`);
+					try {
+						controller.error(err);
+					} catch (e) {
+						// Controller may already be errored
+					}
+				});
+				log('[VLESS] ReadableStream message handlers registered');
+			},
+			cancel() {
+				safeCloseWebSocket(ws);
+			},
+		});
+
+		log('[VLESS] Readable stream created');
+		log('[VLESS] Streams created, generating request header...');
+
+		// Generate and send VLESS request header + initial data
+		log(`[VLESS] Generating header for command=${command}, addressType=${addressType}, address=${addressRemote}, port=${portRemote}`);
+		const vlessHeader = makeVlessRequestHeader(command, addressType, addressRemote, portRemote, config.uuid);
+
+		// Ensure rawClientData is a Uint8Array (it might be ArrayBuffer)
+		let clientData;
+		if (rawClientData instanceof ArrayBuffer) {
+			clientData = new Uint8Array(rawClientData);
+		} else if (rawClientData instanceof Uint8Array) {
+			clientData = rawClientData;
+		} else if (rawClientData && rawClientData.buffer instanceof ArrayBuffer) {
+			// It's already a typed array view
+			clientData = new Uint8Array(rawClientData.buffer, rawClientData.byteOffset, rawClientData.byteLength);
+		} else {
+			// Fallback: try to create from whatever we have
+			clientData = new Uint8Array(rawClientData || 0);
+		}
+
+		log(`[VLESS] Header generated, length=${vlessHeader.length}, clientData length=${clientData.length}`);
+
+		const firstPacket = new Uint8Array(vlessHeader.length + clientData.length);
+		firstPacket.set(vlessHeader, 0);
+		firstPacket.set(clientData, vlessHeader.length);
+
+		log(`[VLESS] Sending first packet, total length=${firstPacket.length}, ws.readyState=${ws.readyState}`);
+		ws.send(firstPacket);
+		log('[VLESS] Sent request header with initial data');
+
+		log('[VLESS] Returning streams and closed promise');
+		return { readable: readableStream, writable: writableStream, closed: closedPromise };
+	} catch (err) {
+		log(`[VLESS] Error after connection opened: ${err.message}`);
+		log(`[VLESS] Error stack: ${err.stack}`);
+		safeCloseWebSocket(ws);
+		closedResolve();
+		return null;
+	}
+}

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -5,6 +5,107 @@
 import { proxyIPs } from '../config/defaults.js';
 
 /**
+ * Parses a VLESS URL into configuration object
+ * Format: vless://uuid@host:port?type=ws&security=tls&path=/path&sni=host#name
+ * @param {string} url - VLESS URL string
+ * @returns {{
+ *   uuid: string,
+ *   address: string,
+ *   port: number,
+ *   streamSettings: {
+ *     network: string,
+ *     security: string,
+ *     wsSettings?: { path: string, headers?: Object },
+ *     tlsSettings?: { serverName: string }
+ *   }
+ * }|null} Parsed configuration or null if invalid
+ */
+export function parseVlessUrl(url) {
+	if (!url || !url.startsWith('vless://')) {
+		return null;
+	}
+
+	try {
+		// Remove 'vless://' prefix and fragment
+		const urlWithoutProtocol = url.slice(8).split('#')[0];
+
+		// Split by @ to get uuid and rest
+		const atIndex = urlWithoutProtocol.indexOf('@');
+		if (atIndex === -1) return null;
+
+		const uuid = urlWithoutProtocol.slice(0, atIndex);
+		const rest = urlWithoutProtocol.slice(atIndex + 1);
+
+		// Parse host:port and query string
+		const [hostPort, queryString] = rest.split('?');
+
+		// Handle IPv6 addresses in brackets
+		let address, port;
+		if (hostPort.startsWith('[')) {
+			// IPv6 format: [::1]:port
+			const bracketEnd = hostPort.indexOf(']');
+			if (bracketEnd === -1) return null;
+			address = hostPort.slice(1, bracketEnd);
+			const portPart = hostPort.slice(bracketEnd + 1);
+			if (portPart.startsWith(':')) {
+				port = parseInt(portPart.slice(1), 10);
+			} else {
+				port = 443; // default port
+			}
+		} else {
+			// IPv4 or domain format
+			const colonIndex = hostPort.lastIndexOf(':');
+			if (colonIndex === -1) {
+				address = hostPort;
+				port = 443; // default port
+			} else {
+				address = hostPort.slice(0, colonIndex);
+				port = parseInt(hostPort.slice(colonIndex + 1), 10);
+			}
+		}
+
+		if (isNaN(port)) port = 443;
+
+		// Parse query parameters
+		const params = {};
+		if (queryString) {
+			queryString.split('&').forEach((pair) => {
+				const [key, value] = pair.split('=');
+				if (key) {
+					params[decodeURIComponent(key)] = decodeURIComponent(value || '');
+				}
+			});
+		}
+
+		// Build stream settings
+		const streamSettings = {
+			network: params.type || 'ws',
+			security: params.security || 'none',
+		};
+
+		if (streamSettings.network === 'ws') {
+			streamSettings.wsSettings = {
+				path: params.path || '/',
+			};
+			if (params.host) {
+				streamSettings.wsSettings.headers = { Host: params.host };
+			}
+		}
+
+		if (streamSettings.security === 'tls') {
+			streamSettings.tlsSettings = {
+				serverName: params.sni || params.host || address,
+			};
+		}
+
+		return { uuid, address, port, streamSettings };
+	} catch (e) {
+		console.error('[VLESS] Failed to parse URL:', e);
+		return null;
+	}
+}
+
+/**
  * Parses SOCKS5 address string into components.
  * @param {string} address - SOCKS5 address string (format: 'username:password@host:port' or 'host:port')
  * @returns {{username: string|undefined, password: string|undefined, hostname: string, port: number}} Parsed address information
@@ -119,15 +220,16 @@ function decodeProxyAddress(address) {
 
 /**
  * Parses path-based proxy parameters.
- * Supports formats: /proxyip=, /proxyip., /socks5=, /socks://, /socks5://, /http=, /http://
+ * Supports formats: /proxyip=, /proxyip., /socks5=, /socks://, /socks5://, /http=, /http://, /vless://
  * @param {string} pathname - URL pathname
- * @returns {{proxyip: string|null, socks5: string|null, http: string|null, globalProxy: boolean}} Parsed parameters
+ * @returns {{proxyip: string|null, socks5: string|null, http: string|null, vless: string|null, globalProxy: boolean}} Parsed parameters
  */
 export function parsePathProxyParams(pathname) {
 	const result = {
 		proxyip: null,
 		socks5: null,
 		http: null,
+		vless: null,
 		globalProxy: false
 	};
 
@@ -173,6 +275,28 @@ export function parsePathProxyParams(pathname) {
 	if (httpEqMatch) {
 		const type = httpEqMatch[1].toLowerCase();
 		result.http = httpEqMatch[2];
+		// g prefix enables global proxy mode
+		if (type.startsWith('g')) {
+			result.globalProxy = true;
+		}
+		return result;
+	}
+
+	// 6. Match /vless://uuid@host:port?...  (VLESS outbound, always global)
+	const vlessUrlMatch = pathname.match(/^\/vless:\/\/([^/?#]+)/i);
+	if (vlessUrlMatch) {
+		// Reconstruct the full VLESS URL
+		const vlessPath = pathname.slice(1); // Remove leading /
+		result.vless = vlessPath;
+		result.globalProxy = true;
+		return result;
+	}
+
+	// 7. Match /vless= or /gvless= (g prefix enables global proxy mode)
+	const vlessEqMatch = pathname.match(/^\/(g?vless)=([^/?#]+)/i);
+	if (vlessEqMatch) {
+		const type = vlessEqMatch[1].toLowerCase();
+		result.vless = decodeURIComponent(vlessEqMatch[2]);
 		// g prefix enables global proxy mode
 		if (type.startsWith('g')) {
 			result.globalProxy = true;


### PR DESCRIPTION
## Summary
- Add VLESS outbound connection module for connecting to external VLESS servers via WebSocket
- Add UDP handler enabling full UDP proxy support when VLESS outbound is configured
- Add VLESS URL parser to support `vless://` protocol URLs
- Support multiple configuration methods: URL path (`/vless://`, `/gvless=`), query parameters (`?vless=`), and environment variable (`VLESS_OUTBOUND`)
- Fix ArrayBuffer to Uint8Array conversion for rawClientData handling
- Add detailed logging throughout connection lifecycle for debugging

## Test plan
- [ ] Test VLESS outbound TCP connections via `/gvless=vless://...` path
- [ ] Test VLESS outbound UDP connections (DNS queries)
- [ ] Verify existing SOCKS5 and HTTP proxy functionality still works
- [ ] Test with curl and v2ray clients